### PR TITLE
Support multiple releases for development

### DIFF
--- a/charts/uws-api-server/templates/ingress.yaml
+++ b/charts/uws-api-server/templates/ingress.yaml
@@ -2,7 +2,7 @@
 kind: Ingress
 apiVersion: extensions/v1beta1
 metadata:
-  name: uws-server
+  name: {{ template "uws-api-server.fullname" $ }}-uws-server
   namespace: uws
   annotations:
     kubernetes.io/ingress.class: nginx

--- a/charts/uws-api-server/templates/ingress.yaml
+++ b/charts/uws-api-server/templates/ingress.yaml
@@ -3,7 +3,6 @@ kind: Ingress
 apiVersion: extensions/v1beta1
 metadata:
   name: {{ template "uws-api-server.fullname" $ }}-uws-server
-  namespace: uws
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /$2
@@ -18,5 +17,5 @@ spec:
         paths:
           - path: /{{ .Values.basePath }}(/|$)(.*)
             backend:
-              serviceName: uws-server
+              serviceName: {{ .Release.Name }}-server
               servicePort: 80

--- a/charts/uws-api-server/templates/ingress.yaml
+++ b/charts/uws-api-server/templates/ingress.yaml
@@ -2,7 +2,7 @@
 kind: Ingress
 apiVersion: extensions/v1beta1
 metadata:
-  name: {{ template "uws-api-server.fullname" $ }}-uws-server
+  name: {{ template "uws-api-server.fullname" $ }}-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /$2

--- a/charts/uws-api-server/templates/ingress.yaml
+++ b/charts/uws-api-server/templates/ingress.yaml
@@ -16,7 +16,7 @@ spec:
     - host: {{ .Values.hostname }}
       http:
         paths:
-          - path: /uws-server(/|$)(.*)
+          - path: /{{ .Values.basePath }}(/|$)(.*)
             backend:
               serviceName: uws-server
               servicePort: 80

--- a/charts/uws-api-server/templates/volumes.yaml
+++ b/charts/uws-api-server/templates/volumes.yaml
@@ -19,7 +19,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: uws-server-pvc
+  name: {{ .Values.workingVolume.claimName }}
   labels:
     app: {{ template "uws-api-server.fullname" $ }}
     chart: {{ template "uws-api-server.chart" $ }}

--- a/charts/uws-api-server/values-nts-dev.yaml
+++ b/charts/uws-api-server/values-nts-dev.yaml
@@ -1,0 +1,40 @@
+targetCluster: "nts"
+hostname: lsst-nts-k8s.ncsa.illinois.edu
+
+workingVolume:
+  name: job-files
+  server: lsst-l1-cl-arctl.ncsa.illinois.edu
+  exportPath: "/scratch/uws"
+  claimName: uws-dev-server-pvc
+  mountPath: "/uws"
+  subPath: "dev"
+
+volumes:
+- name: repo
+  server: lsst-l1-cl-arctl.ncsa.illinois.edu
+  claimName: dev-repo-pvc
+  mountPath: "/repo"
+  exportPath: "/repo"
+  subPath: ""
+  readOnly: false
+- name: project
+  server: lsst-l1-cl-arctl.ncsa.illinois.edu
+  claimName: dev-project-pvc
+  mountPath: "/project"
+  exportPath: "/project"
+  subPath: ""
+  readOnly: false
+- name: data
+  server: lsst-l1-cl-arctl.ncsa.illinois.edu
+  claimName: dev-data-pvc
+  mountPath: "/data/lsstdata/NTS"
+  exportPath: "/data/lsstdata/NTS"
+  subPath: ""
+  readOnly: true
+- name: home
+  server: lsst-l1-cl-arctl.ncsa.illinois.edu
+  claimName: dev-home-pvc
+  mountPath: "/jhome"
+  exportPath: "/jhome"
+  subPath: ""
+  readOnly: false

--- a/charts/uws-api-server/values-nts-dev.yaml
+++ b/charts/uws-api-server/values-nts-dev.yaml
@@ -1,5 +1,6 @@
 targetCluster: "nts"
 hostname: lsst-nts-k8s.ncsa.illinois.edu
+basePath: "dev-uws-server"
 
 workingVolume:
   name: job-files

--- a/charts/uws-api-server/values-nts-dev.yaml
+++ b/charts/uws-api-server/values-nts-dev.yaml
@@ -6,7 +6,7 @@ workingVolume:
   name: job-files
   server: lsst-l1-cl-arctl.ncsa.illinois.edu
   exportPath: "/scratch/uws"
-  claimName: uws-dev-server-pvc
+  claimName: dev-uws-server-pvc
   mountPath: "/uws"
   subPath: "dev"
 

--- a/charts/uws-api-server/values.yaml
+++ b/charts/uws-api-server/values.yaml
@@ -11,6 +11,7 @@ image:
 # Target Kubernetes cluster
 targetCluster: ""
 hostname: ""
+basePath: "uws-server"
 
 # Log level of server. Set to "DEBUG" for highest verbosity.
 logLevel: "WARNING"


### PR DESCRIPTION
In order to support multiple concurrent releases for development purposes, several templates had to be updated. Related to https://github.com/lsst-dm/uws-api-server/pull/5